### PR TITLE
Divining race registration from practice

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -95,10 +95,12 @@ class Session(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    @property
     def isPractice(self):
         """ Note: This is true also if this is a pre-race practice, automatic registration """
         return self.eventTypeId == 2
 
+    @property
     def isRace(self):
         """ Returns True only if this is a pure race session; returns false if this is a pre-race practice """
         # Session types are test 1, practice 2, qualify 3, time trial 4, race 5.
@@ -116,7 +118,7 @@ class Session(object):
          It requires a minimum amount of time to have passed between data """
 
         # Firstly, this must be a practice to be a pre-race practice
-        if not self.isPractice():
+        if not self.isPractice:
             return False
 
         # If no previous session is available, we cannot say that this is a pre-race session yet.
@@ -540,7 +542,7 @@ class Racebot(callbacks.Plugin):
                 # This guy does not want to be spied
                 continue
 
-            isRaceSession = session.isRace()
+            isRaceSession = session.isRace
 
             for channel in irc.state.channels:
                 relevantConfigValue = 'raceRegistrationAlerts' if isRaceSession else 'nonRaceRegistrationAlerts'

--- a/plugin.py
+++ b/plugin.py
@@ -298,12 +298,11 @@ class IRacingData:
             driver = Driver(racerJSON, self.db)
             self.driversByID[driver.id] = driver
 
-
     def onlineDrivers(self):
         """Returns an array of all online Driver()s"""
         drivers = []
 
-        for driverID, driver in self.driversByID.items():
+        for _, driver in self.driversByID.items():
             if driver.isOnline:
                 drivers.append(driver)
 

--- a/plugin.py
+++ b/plugin.py
@@ -174,7 +174,6 @@ class Driver(object):
         @type db: RacebotDB
         """
 
-        self.json = json
         self.db = db
         self.id = json['custid']
         self.name = json['name']
@@ -200,6 +199,8 @@ class Driver(object):
         return not self.__eq__(other)
 
     def _updateCurrentSessionWithJson(self, json):
+        self.json = json
+
         if self._isInASessionWithJson(json):
             if self.currentSession is not None:
                 self.currentSession = Session(json, previousSession=self.currentSession)
@@ -213,11 +214,7 @@ class Driver(object):
         (The initial version uses the previous data vs. the current data to discover if the driver is registered
         for a race.)"""
 
-        # Compare old session to new
         self._updateCurrentSessionWithJson(json)
-
-        # Replace old data with new
-        self.json = json
 
     @property
     def nickname(self):

--- a/plugin.py
+++ b/plugin.py
@@ -52,9 +52,10 @@ class Session(object):
     # If we see someone registered for a practice without joining for this long, we can assume the server is holding
     #  this practice slot for a pre-race practice.  If it is not a pre-race practice, he will have been removed from
     #  the session if he has not joined in this much time.
-
-    # TODO: Establish a meaningful value for this through testing
-    MINIMUM_TIME_BETWEEN_PRACTICE_DATA_TO_DETERMINE_RACE_SECONDS = 120
+    # It seems that five minutes is the time before iRacing removes your practice registration for a non-pre-race
+    #  practice, but we can reasonably cut this down to two or three minutes.  Who registers for a practice and does
+    #  not actually join for three minutes?  Not many people.
+    MINIMUM_TIME_BETWEEN_PRACTICE_DATA_TO_DETERMINE_RACE_SECONDS = 180
 
     def __init__(self, driverJson, previousSession=None):
         """

--- a/plugin.py
+++ b/plugin.py
@@ -246,7 +246,8 @@ class Driver(object):
 
     @property
     def allowRaceAlerts(self):
-        return self.db.allowRaceAlertsForDriver(self)
+        # Do not allow race alerts if we do not have a nickname for this driver.
+        return False if self.nickname is None else self.db.allowRaceAlertsForDriver(self)
 
     @allowRaceAlerts.setter
     def allowRaceAlerts(self, theAllowRaceAlerts):
@@ -254,7 +255,8 @@ class Driver(object):
 
     @property
     def allowOnlineQuery(self):
-        return self.db.allowOnlineQueryForDriver(self)
+        # Do not allow online query if we do not have a nickname for this driver.
+        return False if self.nickname is None else self.db.allowOnlineQueryForDriver(self)
 
     @allowOnlineQuery.setter
     def allowOnlineQuery(self, theAllowOnlineQuery):

--- a/plugin.py
+++ b/plugin.py
@@ -481,7 +481,7 @@ class RacebotDB(object):
 
     def nickForDriver(self, driver):
         row = self._rowForDriver(driver)
-        return None if row is None else row['nick']
+        return None if (row is None or 'nick' is not in row) else row['nick']
 
     def allowNickRevealForDriver(self, driver):
         row = self._rowForDriver(driver)

--- a/plugin.py
+++ b/plugin.py
@@ -130,7 +130,7 @@ class Session(object):
         # Calculate the time between data points.  If it's been too soon, we cannot differentiate between a pre-race
         #  practice where the spot will be held forever vs. a normal practice
         timeDelta = self.updateTime - self.oldestDataThisSession.updateTime
-        if timeDelta > MINIMUM_TIME_BETWEEN_PRACTICE_DATA_TO_DETERMINE_RACE_SECONDS:
+        if timeDelta < MINIMUM_TIME_BETWEEN_PRACTICE_DATA_TO_DETERMINE_RACE_SECONDS:
             return False
 
         # Enough time has passed.  If this user has stayed registered but not joined, we may have a pre-race prac!

--- a/plugin.py
+++ b/plugin.py
@@ -123,7 +123,7 @@ class Session(object):
             return False
 
         # If no previous session is available, we cannot say that this is a pre-race session yet.
-        if self.oldestDataThisSession == None:
+        if self._oldestDataThisSession == None:
             return False
 
         # Ensure that the user had not joined the previous session.  If the user has joined the previous session,

--- a/plugin.py
+++ b/plugin.py
@@ -267,7 +267,6 @@ class IRacingData:
     """Aggregates all driver and session data into dictionaries."""
 
     driversByID = {}
-    sessionByID = {}
     latestGetDriverStatusJSON = None
 
     def __init__(self, iRacingConnection, db):
@@ -286,10 +285,6 @@ class IRacingData:
         for racerJSON in self.latestGetDriverStatusJSON["fsRacers"]:
             driver = Driver(racerJSON, self.db)
             self.driversByID[driver.id] = driver
-
-            if driver.isInASession():
-                session = driver.currentSession()
-                self.sessionByID[session.id] = session
 
 
     def onlineDrivers(self):

--- a/plugin.py
+++ b/plugin.py
@@ -482,7 +482,7 @@ class RacebotDB(object):
 
     def nickForDriver(self, driver):
         row = self._rowForDriver(driver)
-        return None if (row is None or 'nick' is not in row) else row['nick']
+        return None if (row is None or 'nick' not in row) else row['nick']
 
     def allowNickRevealForDriver(self, driver):
         row = self._rowForDriver(driver)

--- a/plugin.py
+++ b/plugin.py
@@ -107,6 +107,7 @@ class Session(object):
         # If only Python 2 had enums
         return self.eventTypeId == 5
 
+    @property
     def userRegisteredButHasNotJoined(self):
         return self.regStatus == 'reg_ok_to_join'
 
@@ -128,7 +129,7 @@ class Session(object):
         # Ensure that the user had not joined the previous session.  If the user has joined the previous session,
         #  it does not necessarily mean that this is not a pre-race practice; it means that we cannot divine that it is
         #  so with this data, even if it is true :(
-        if not self.oldestDataThisSession.userRegisteredButHasNotJoined():
+        if not self.oldestDataThisSession.userRegisteredButHasNotJoined:
             return False
 
         # Calculate the time between data points.  If it's been too soon, we cannot differentiate between a pre-race
@@ -138,7 +139,7 @@ class Session(object):
             return False
 
         # Enough time has passed.  If this user has stayed registered but not joined, we may have a pre-race prac!
-        if self.userRegisteredButHasNotJoined():
+        if self.userRegisteredButHasNotJoined:
             return True
 
         return False

--- a/plugin.py
+++ b/plugin.py
@@ -108,6 +108,10 @@ class Session(object):
         return self.eventTypeId == 5
 
     @property
+    def isRaceOrPreRacePractice(self):
+        return self.isRace or self.isPotentiallyPreRaceSession
+
+    @property
     def userRegisteredButHasNotJoined(self):
         return self.regStatus == 'reg_ok_to_join'
 
@@ -476,19 +480,24 @@ class RacebotDB(object):
         return row
 
     def nickForDriver(self, driver):
-        return self._rowForDriver(driver)['nick']
+        row = self._rowForDriver(driver)
+        return None if row is None else row['nick']
 
     def allowNickRevealForDriver(self, driver):
-        return self._rowForDriver(driver)['allow_nick_reveal']
+        row = self._rowForDriver(driver)
+        return None if row is None else row['allow_nick_reveal']
 
     def allowNameRevealForDriver(self, driver):
-        return self._rowForDriver(driver)['allow_name_reveal']
+        row = self._rowForDriver(driver)
+        return None if row is None else row['allow_name_reveal']
 
     def allowRaceAlertsForDriver(self, driver):
-        return self._rowForDriver(driver)['allow_race_alerts']
+        row = self._rowForDriver(driver)
+        return None if row is None else row['allow_race_alerts']
 
     def allowOnlineQueryForDriver(self, driver):
-        return self._rowForDriver(driver)['allow_online_query']
+        row = self._rowForDriver(driver)
+        return None if row is None else row['allow_online_query']
 
 
 
@@ -544,7 +553,7 @@ class Racebot(callbacks.Plugin):
                 # This guy does not want to be spied
                 continue
 
-            isRaceSession = session.isRace
+            isRaceSession = session.isRaceOrPreRacePractice
 
             for channel in irc.state.channels:
                 relevantConfigValue = 'raceRegistrationAlerts' if isRaceSession else 'nonRaceRegistrationAlerts'

--- a/plugin.py
+++ b/plugin.py
@@ -280,7 +280,6 @@ class IRacingData:
     """Aggregates all driver and session data into dictionaries."""
 
     driversByID = {}
-    latestGetDriverStatusJSON = None
 
     def __init__(self, iRacingConnection, db):
         self.iRacingConnection = iRacingConnection
@@ -290,12 +289,12 @@ class IRacingData:
 
     def grabData(self, onlineOnly=True):
         """Refreshes data from iRacing JSON API."""
-        self.latestGetDriverStatusJSON = self.iRacingConnection.fetchDriverStatusJSON(onlineOnly=onlineOnly)
+        json = self.iRacingConnection.fetchDriverStatusJSON(onlineOnly=onlineOnly)
 
         # Populate drivers and sessions dictionaries
         # This could be made possibly more efficient by reusing existing Driver and Session objects,
         # but we'll be destructive and wasteful for now.
-        for racerJSON in self.latestGetDriverStatusJSON["fsRacers"]:
+        for racerJSON in json["fsRacers"]:
             driver = Driver(racerJSON, self.db)
             self.driversByID[driver.id] = driver
 

--- a/plugin.py
+++ b/plugin.py
@@ -214,10 +214,7 @@ class Driver(object):
         for a race.)"""
 
         # Compare old session to new
-        oldSession = self.currentSession
         self._updateCurrentSessionWithJson(json)
-
-
 
         # Replace old data with new
         self.json = json

--- a/plugin.py
+++ b/plugin.py
@@ -113,6 +113,10 @@ class Session(object):
         True if this session is a practice where the user is registered but has still not joined since our last tick
          It requires a minimum amount of time to have passed between data """
 
+        # Firstly, this must be a practice to be a pre-race practice
+        if not self.isPractice():
+            return False
+
         # If no previous session is available, we cannot say that this is a pre-race session yet.
         if self.oldestDataThisSession == None:
             return False
@@ -126,7 +130,7 @@ class Session(object):
         # Calculate the time between data points.  If it's been too soon, we cannot differentiate between a pre-race
         #  practice where the spot will be held forever vs. a normal practice
         timeDelta = self.updateTime - self.oldestDataThisSession.updateTime
-        if timeDelta < MINIMUM_TIME_BETWEEN_PRACTICE_DATA_TO_DETERMINE_RACE_SECONDS:
+        if timeDelta > MINIMUM_TIME_BETWEEN_PRACTICE_DATA_TO_DETERMINE_RACE_SECONDS:
             return False
 
         # Enough time has passed.  If this user has stayed registered but not joined, we may have a pre-race prac!

--- a/plugin.py
+++ b/plugin.py
@@ -52,6 +52,8 @@ class Session(object):
     # If we see someone registered for a practice without joining for this long, we can assume the server is holding
     #  this practice slot for a pre-race practice.  If it is not a pre-race practice, he will have been removed from
     #  the session if he has not joined in this much time.
+
+    # TODO: Establish a meaningful value for this through testing
     MINIMUM_TIME_BETWEEN_PRACTICE_DATA_TO_DETERMINE_RACE_SECONDS = 120
 
     def __init__(self, driverJson, previousSession=None):

--- a/plugin.py
+++ b/plugin.py
@@ -150,6 +150,7 @@ class Session(object):
             return self._oldestDataThisSession
         return self
 
+    @property
     def sessionDescription(self):
         isRace = False
 
@@ -550,7 +551,7 @@ class Racebot(callbacks.Plugin):
                 shouldBroadcast = self.registryValue(relevantConfigValue, channel)
 
                 if shouldBroadcast:
-                    message = '%s is registered for a %s' % (driver.nameForPrinting(), session.sessionDescription().lower())
+                    message = '%s is registered for a %s' % (driver.nameForPrinting(), session.sessionDescription.lower())
                     irc.queueMsg(ircmsgs.privmsg(channel, message))
 
     def racers(self, irc, msg, args):

--- a/plugin.py
+++ b/plugin.py
@@ -151,17 +151,23 @@ class Session(object):
         return self
 
     def sessionDescription(self):
+        isRace = False
+
         if self.eventTypeId == 1:
             return 'Test Session'
         elif self.eventTypeId == 2:
             if self.isPotentiallyPreRaceSession:
-                return 'Race'
-            return 'Practice Session'
+                isRace = True
+            else:
+                return 'Practice Session'
         elif self.eventTypeId == 3:
             return 'Qualifying Session'
         elif self.eventTypeId == 4:
             return 'Time Trial'
         elif self.eventTypeId == 5:
+            isRace = True
+
+        if isRace:
             return 'Race'
 
         return 'Unknown Session Type'


### PR DESCRIPTION
Added the ability to determine if a user is in a pre-race practice session since iRacing does not indicate that a user is registered to race before the race begins now that pre-race practice sessions exist.
